### PR TITLE
Add page bundle support for thumbnails, copied from Ananke theme

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,6 +4,14 @@
     <div class="thumbnail" style="box-shadow: var(--box-shadow); height: {{ .height }};">
         <img src={{ .src | absURL }} style="object-position: {{ .object_position }};" title={{ .alt | default "thumbnail" }} alt={{ .alt | default "thumbnail" }} loading="lazy">
     </div>
+    {{ else }}
+        {{ with .Resources.ByType "image" }}
+            {{ with .GetMatch (printf "**{%s}*" "feature,cover,thumbnail") }}
+    <div class="thumbnail" style="box-shadow: var(--box-shadow);">
+        <img src={{ .RelPermalink | absURL }} alt="thumbnail" title="thumbnail" loading="lazy">
+    </div>
+            {{ end }}
+        {{ end }}
     {{ end }}
     <div class="post-title">
         <h1>{{ .Title }}</h1>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,6 +9,16 @@
                         <img src={{ .src | absURL }} style="object-position: {{ .object_position }};" alt={{ .alt | default "thumbnail" }} title={{ .alt | default "thumbnail" }} loading="lazy">
                     </a>
                 </div>
+            {{ else }}
+                {{ with .Resources.ByType "image" }}
+                    {{ with .GetMatch (printf "**{%s}*" "feature,cover,thumbnail") }}
+                 <div class="thumbnail">
+                    <a href={{ $permalink }}>
+                        <img src={{ .RelPermalink | absURL }} alt="thumbnail" title="thumbnail" loading="lazy">
+                    </a>
+                </div>
+                    {{ end }}
+                {{ end }}
             {{ end }}
             <div class="post-text grow">
                 <div class="post-title">


### PR DESCRIPTION
Very preliminary support for common "cover" pictures found in Hugo page bundles.

It's not as sophisticated as front matter declarations because it's not feasible to gain heuristics about **intended** picture height, caption texts, etc., just out of file names. Maybe this could be further supported using front matters. At the very least, this can help me accelerate my conversion from WordPress export to Hugo utilizing page bundles.

Code shamelessly borrowed from [https://github.com/theNewDynamic/gohugo-theme-ananke/blob/master/layouts/partials/func/GetFeaturedImage.html](Ananke); it's duplicated in 2 places because it'd be nice to combine the thumbnail support and Ananke's code itself only expands the URL of the picture (I started using Hugo yesterday, so this is really beyond me :rofl:  )